### PR TITLE
Fix task retry bug

### DIFF
--- a/kombu/__init__.py
+++ b/kombu/__init__.py
@@ -11,7 +11,7 @@ version_info_t = namedtuple(
     'version_info_t', ('major', 'minor', 'micro', 'releaselevel', 'serial'),
 )
 
-VERSION = version_info_t(3, 0, 35, '', '')
+VERSION = version_info_t(3, 0, 36, '', '')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/kombu/transport/SQS.py
+++ b/kombu/transport/SQS.py
@@ -420,8 +420,8 @@ class Channel(virtual.Channel):
         return super(Channel, self)._restore(message)
 
     def basic_ack(self, delivery_tag):
-        delivery_info = self.qos.get(delivery_tag).delivery_info
         try:
+            delivery_info = self.qos.get(delivery_tag).delivery_info
             queue = delivery_info['sqs_queue']
         except KeyError:
             pass


### PR DESCRIPTION
When acks_late is set and a retry is triggered, one of the tasks (original or retry) tries to ack when the task has already been acked and deleted.